### PR TITLE
Fix vector in srm

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -134,11 +134,14 @@ namespace System.Text.RegularExpressions
         /// </summary>
         private static SRM.Regex InitializeSRM(RegexNode rootNode, RegexOptions options)
         {
-            // TBD: this could potentially be supported quite easily
+            // TBD: this could potentially be supported quite easily but is not of priority
             // it essentially affects how the iput string is being processed  -- characters are read backwards --
             // and what the right semantics of anchors is in this case (perhaps still unchanged)
             if ((options & RegexOptions.RightToLeft) != 0)
                 throw new NotSupportedException(SRM.Regex._DFA_incompatible_with + RegexOptions.RightToLeft);
+            // TBD: this could also be supported easily, but is not of priority
+            if ((options & RegexOptions.ECMAScript) != 0)
+                throw new NotSupportedException(SRM.Regex._DFA_incompatible_with + RegexOptions.ECMAScript);
 
             return new SRM.Regex(rootNode, options);
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -14,7 +14,7 @@ using System.Threading;
 namespace System.Text.RegularExpressions
 {
     /// <summary>
-    /// Represents an immutable regular expression. Also contains static methods that
+    /// Represents an  immutable regular expression. Also contains static methods that
     /// allow use of regular expressions without instantiating a Regex explicitly.
     /// </summary>
     public partial class Regex : ISerializable

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -118,11 +118,11 @@ namespace System.Text.RegularExpressions.SRM
         ushort A_StartSet_singleton;
 #endif
 
-        /// <summary>
-        /// First byte of A_prefixUTF8 in vector
-        /// </summary>
-        [NonSerialized]
-        private Vector<byte> A_prefixUTF8_first_byte;
+        ///// <summary>
+        ///// First byte of A_prefixUTF8 in vector
+        ///// </summary>
+        //[NonSerialized]
+        //private Vector<byte> A_prefixUTF8_first_byte;
 
         /// <summary>
         /// Original regex.
@@ -417,7 +417,7 @@ namespace System.Text.RegularExpressions.SRM
             this.Ar_prefix_array = (S[])info.GetValue("Ar_prefix_array", typeof(S[]));
             this.Ar_prefix = StringUtility.DeserializeStringFromCharCodeSequence(info.GetString("Ar_prefix"));
 
-            InitializeVectors();
+            //InitializeVectors();
         }
 
         /// <summary>
@@ -481,7 +481,7 @@ namespace System.Text.RegularExpressions.SRM
             this.Ar_prefix_array = Ar.GetPrefix();
             this.Ar_prefix = new string(Array.ConvertAll(this.Ar_prefix_array, x => (char)css.GetMin(builder.solver.ConvertToCharSet(css, x))));
 
-            InitializeVectors();
+            //InitializeVectors();
         }
 
         private void InitializeRegexes()
@@ -528,22 +528,22 @@ namespace System.Text.RegularExpressions.SRM
             }
         }
 
-        private void InitializeVectors()
-        {
-#if UNSAFE
-            if (A_StartSet_Size > 0 && A_StartSet_Size <= StartSetSizeLimit)
-            {
-                char[] startchars = new List<char>(builder.solver.GenerateAllCharacters(A_startset)).ToArray();
-                A_StartSet_Vec = Array.ConvertAll(startchars, c => new Vector<ushort>(c));
-                A_StartSet_singleton = (ushort)startchars[0];
-            }
-#endif
+//        private void InitializeVectors()
+//        {
+//#if UNSAFE
+//            if (A_StartSet_Size > 0 && A_StartSet_Size <= StartSetSizeLimit)
+//            {
+//                char[] startchars = new List<char>(builder.solver.GenerateAllCharacters(A_startset)).ToArray();
+//                A_StartSet_Vec = Array.ConvertAll(startchars, c => new Vector<ushort>(c));
+//                A_StartSet_singleton = (ushort)startchars[0];
+//            }
+//#endif
 
-            if (this.A_prefix != string.Empty)
-            {
-                this.A_prefixUTF8_first_byte = new Vector<byte>(this.A_prefixUTF8[0]);
-            }
-        }
+//            if (this.A_prefix != string.Empty)
+//            {
+//                this.A_prefixUTF8_first_byte = new Vector<byte>(this.A_prefixUTF8[0]);
+//            }
+//        }
 
         /// <summary>
         /// Return the state after the given input string from the given state q.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/UnicodeCategoryTheory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/UnicodeCategoryTheory.cs
@@ -91,8 +91,14 @@ namespace System.Text.RegularExpressions.SRM
 
         public UnicodeCategoryTheory(ICharAlgebra<PRED> solver)
         {
+#if DEBUG
+            if (solver.Encoding != BitWidth.BV16)
+                throw new AutomataException(AutomataExceptionKind.InternalError_SymbolicRegex);
+#endif
+
             this.solver = solver;
-            InitializeUnicodeCategoryDefinitions();
+            // remove initialization, since the predicate creation is lazy and on demand
+            // InitializeUnicodeCategoryDefinitions();
         }
 
         private PRED MkRangesConstraint(IEnumerable<int[]> ranges)
@@ -103,51 +109,53 @@ namespace System.Text.RegularExpressions.SRM
             return res;
         }
 
-        private void InitializeUnicodeCategoryDefinitions()
-        {
-            if (solver.Encoding == BitWidth.BV7)
-            {
-                //use ranges directly
-                for (int i = 0; i < 30; i++)
-                    if (UnicodeCategoryRanges.ASCII[i] == null)
-                        catConditions[i] = solver.False;
-                    else
-                        catConditions[i] = solver.MkCharPredicate(
-                              UnicodeCategoryPredicateName(i), MkRangesConstraint(UnicodeCategoryRanges.ASCII[i]));
+        //private void InitializeUnicodeCategoryDefinitions()
+        //{
+        //    if (solver.Encoding == BitWidth.BV7)
+        //    {
+        //        // depricated case
+        //        //use ranges directly
+        //        for (int i = 0; i < 30; i++)
+        //            if (UnicodeCategoryRanges.ASCII[i] == null)
+        //                catConditions[i] = solver.False;
+        //            else
+        //                catConditions[i] = solver.MkCharPredicate(
+        //                      UnicodeCategoryPredicateName(i), MkRangesConstraint(UnicodeCategoryRanges.ASCII[i]));
 
-                whiteSpaceCondition = solver.MkCharPredicate(
-                              "IsWhitespace", MkRangesConstraint(UnicodeCategoryRanges.ASCIIWhitespace));
-                wordLetterCondition = solver.MkCharPredicate(
-                              "IsWordletter", MkRangesConstraint(UnicodeCategoryRanges.ASCIIWordCharacter));
-            }
-            else if (solver.Encoding == BitWidth.BV8)
-            {
-                //use BDDs
-                for (int i = 0; i < 30; i++)
-                    if (UnicodeCategoryRanges.CP437Bdd[i] == null)
-                        catConditions[i] = solver.False;
-                    else
-                        catConditions[i] = solver.MkCharPredicate(
-                              UnicodeCategoryPredicateName(i),
-                              solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.CP437Bdd[i])));
-                whiteSpaceCondition = solver.MkCharPredicate("IsWhitespace",
-                             solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.CP437WhitespaceBdd)));
-                wordLetterCondition = solver.MkCharPredicate("IsWordletter",
-                             solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.CP437WordCharacterBdd)));
-            }
-            else
-            {
-                //use BDDs
-                for (int i = 0; i < 30; i++)
-                    catConditions[i] = solver.MkCharPredicate(
-                         UnicodeCategoryPredicateName(i),
-                         solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.UnicodeBdd[i])));
-                whiteSpaceCondition = solver.MkCharPredicate("IsWhitespace",
-                             solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.UnicodeWhitespaceBdd)));
-                wordLetterCondition = solver.MkCharPredicate("IsWordletter",
-                             solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.UnicodeWordCharacterBdd)));
-            }
-        }
+        //        whiteSpaceCondition = solver.MkCharPredicate(
+        //                      "IsWhitespace", MkRangesConstraint(UnicodeCategoryRanges.ASCIIWhitespace));
+        //        wordLetterCondition = solver.MkCharPredicate(
+        //                      "IsWordletter", MkRangesConstraint(UnicodeCategoryRanges.ASCIIWordCharacter));
+        //    }
+        //    else if (solver.Encoding == BitWidth.BV8)
+        //    {
+        //        // depricated case
+        //        //use BDDs
+        //        for (int i = 0; i < 30; i++)
+        //            if (UnicodeCategoryRanges.CP437Bdd[i] == null)
+        //                catConditions[i] = solver.False;
+        //            else
+        //                catConditions[i] = solver.MkCharPredicate(
+        //                      UnicodeCategoryPredicateName(i),
+        //                      solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.CP437Bdd[i])));
+        //        whiteSpaceCondition = solver.MkCharPredicate("IsWhitespace",
+        //                     solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.CP437WhitespaceBdd)));
+        //        wordLetterCondition = solver.MkCharPredicate("IsWordletter",
+        //                     solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.CP437WordCharacterBdd)));
+        //    }
+        //    else
+        //    {
+        //        //use BDDs
+        //        for (int i = 0; i < 30; i++)
+        //            catConditions[i] = solver.MkCharPredicate(
+        //                 UnicodeCategoryPredicateName(i),
+        //                 solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.UnicodeBdd[i])));
+        //        whiteSpaceCondition = solver.MkCharPredicate("IsWhitespace",
+        //                     solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.UnicodeWhitespaceBdd)));
+        //        wordLetterCondition = solver.MkCharPredicate("IsWordletter",
+        //                     solver.ConvertFromCharSet(solver.CharSetProvider.DeserializeCompact(UnicodeCategoryRanges.UnicodeWordCharacterBdd)));
+        //    }
+        //}
 
         #region IUnicodeCategoryTheory<Expr> Members
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -90,8 +90,9 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)(-1), new TimeSpan()));
 
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x400));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x400, new TimeSpan()));
+            // 0x400 is new DFA option that must no longer throw ArgumentOutOfRangeException, option 0x800 in still out of range
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x800));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x800, new TimeSpan()));
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.RightToLeft));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture));

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -367,8 +367,9 @@ namespace System.Text.RegularExpressions.Tests
             // Options are invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1), TimeSpan.FromSeconds(1)));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x400));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x400, TimeSpan.FromSeconds(1)));
+            // 0x400 is new DFA mode that is now valid, 0x800 is still invalid
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800, TimeSpan.FromSeconds(1)));
 
             // MatchTimeout is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.Matches("input", "pattern", RegexOptions.None, TimeSpan.Zero));

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -166,7 +166,7 @@ namespace System.Text.RegularExpressions.Tests
 
                 string[] possible_errors = new string[]
                 {"RightToLeft", "conditional", "lookahead", "lookbehind", "backreference",
-                    "atomic", "contiguous", "characterless", "0-length match"};
+                    "atomic", "contiguous", "characterless", "0-length match", "ECMAScript"};
 
                 Assert.True(Array.Exists(possible_errors, nse.Message.Contains));
 
@@ -225,6 +225,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             yield return new object[] { @"\A(abc)*\Z", RegexOptions.None, "0-length match" };
             yield return new object[] { @"abc", RegexOptions.RightToLeft, "RightToLeft" };
+            yield return new object[] { @"abc", RegexOptions.ECMAScript, "ECMAScript" };
             yield return new object[] { @"^(a)?(?(1)a|b)+$", RegexOptions.None, "captured group conditional" };
             yield return new object[] { @"(abc)\1", RegexOptions.None, "backreference" };
             yield return new object[] { @"a(?=d).", RegexOptions.None, "positive lookahead" };
@@ -1360,8 +1361,8 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("aba|bab", "baaabbbaba", "(6,9)")]
         [InlineData("(aa|aaa)*|(a|aaaaa)", "aa", "(0,2)(0,2)")]
         [InlineData("(a.|.a.)*|(a|.a...)", "aa", "(0,2)(0,2)")]
-        //[InlineData("ab|a", "xabc", "(1,3)")]
-        //[InlineData("ab|a", "xxabc", "(2,4)")]
+        [InlineData("ab|a", "xabc", "(1,2)")] // is (1,3) in non-DFA mode in AttRegexTests.Test
+        [InlineData("ab|a", "xxabc", "(2,3)")] // is (2,4) in non-DFA mode in AttRegexTests.Test
         [InlineData("(?i)(Ab|cD)*", "aBcD", "(0,4)(2,4)")]
         [InlineData("[^-]", "--a", "(2,3)")]
         [InlineData("[a-]*", "--a", "(0,3)")]
@@ -1528,17 +1529,17 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("X(.?){7,8}Y", "X1234567Y", "(0,9)(8,8)")] // was "(0,9)(7,8)"
         [InlineData("X(.?){8,8}Y", "X1234567Y", "(0,9)(8,8)")]
         [InlineData("(a|ab|c|bcd){0,}(d*)", "ababcd", "(0,1)(1,1)")] // was "(0,6)(3,6)(6,6)"
-        //[InlineData("(a|ab|c|bcd){1,}(d*)", "ababcd", "(0,1)(1,1)")] // was "(0,6)(3,6)(6,6)"
+        [InlineData("(a|ab|c|bcd){1,}(d*)", "ababcd", "(0,6)")] // is "(0,1)(1,1)" in non DFA mode and was "(0,6)(3,6)(6,6)"
         [InlineData("(a|ab|c|bcd){2,}(d*)", "ababcd", "(0,6)(3,6)(6,6)")]
         [InlineData("(a|ab|c|bcd){3,}(d*)", "ababcd", "(0,6)(3,6)(6,6)")]
         [InlineData("(a|ab|c|bcd){4,}(d*)", "ababcd", "NOMATCH")]
         [InlineData("(a|ab|c|bcd){0,10}(d*)", "ababcd", "(0,1)(1,1)")] // was "(0,6)(3,6)(6,6)"
-        //[InlineData("(a|ab|c|bcd){1,10}(d*)", "ababcd", "(0,1)(1,1)")] // was "(0,6)(3,6)(6,6)"
+        [InlineData("(a|ab|c|bcd){1,10}(d*)", "ababcd", "(0,6)")] // is "(0,1)(1,1)" in non DFA mode and was "(0,6)(3,6)(6,6)"
         [InlineData("(a|ab|c|bcd){2,10}(d*)", "ababcd", "(0,6)(3,6)(6,6)")]
         [InlineData("(a|ab|c|bcd){3,10}(d*)", "ababcd", "(0,6)(3,6)(6,6)")]
         [InlineData("(a|ab|c|bcd){4,10}(d*)", "ababcd", "NOMATCH")]
         [InlineData("(a|ab|c|bcd)*(d*)", "ababcd", "(0,1)(1,1)")] // was "(0,6)(3,6)(6,6)"
-        //[InlineData("(a|ab|c|bcd)+(d*)", "ababcd", "(0,1)(1,1)")] // was "(0,6)(3,6)(6,6)"
+        [InlineData("(a|ab|c|bcd)+(d*)", "ababcd", "(0,6)")] // is "(0,1)(1,1)" in non DFA mode was "(0,6)(3,6)(6,6)"
         [InlineData("(ab|a|c|bcd){0,}(d*)", "ababcd", "(0,6)(4,5)(5,6)")] // was "(0,6)(3,6)(6,6)"
         [InlineData("(ab|a|c|bcd){1,}(d*)", "ababcd", "(0,6)(4,5)(5,6)")] // was "(0,6)(3,6)(6,6)"
         [InlineData("(ab|a|c|bcd){2,}(d*)", "ababcd", "(0,6)(4,5)(5,6)")] // was "(0,6)(3,6)(6,6)"


### PR DESCRIPTION
Commenting out use of Vector<T> that was used without guarding it with Vector.IsHardwareAccelerated. --- this caused compilation error.
In the current setting in SRM a field of type Vector<T> was declared but in fact not 
used because the vectorization code is in fact not enabled. This will be revisited.
